### PR TITLE
use historyApiFallback rewrite

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -39,6 +39,10 @@ const config: ConfigurationFactory = (_env, { mode }) => {
     headers: {
       'Access-Control-Allow-Origin': '*',
     },
+
+    historyApiFallback: {
+      rewrites: [{ from: /^\/*/, to: '/index.html' }],
+    },
     open: false,
     inline: true,
     hot: true,


### PR DESCRIPTION
webpack-dev-server response only physical file, so return 404 when reloaded path provided history api ( from react-router) .

fix this.